### PR TITLE
Fix x86 build: ensure that UNISP_NAME is null-terminated

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,8 +87,9 @@ impl SchannelCredBuilder {
                 Direction::Outbound => SECPKG_CRED_OUTBOUND,
             };
 
+            let mut unisp_name = UNISP_NAME.bytes().chain(Some(0u8)).collect::<Vec<u8>>();
             match AcquireCredentialsHandleA(ptr::null_mut(),
-                                            UNISP_NAME.as_ptr() as *mut _,
+                                            unisp_name.as_mut_slice() as *mut _ as *mut _,
                                             direction,
                                             ptr::null_mut(),
                                             &mut cred_data as *mut _ as *mut _,


### PR DESCRIPTION
The x86 build currently is failing for schannel on appveyor.

This seems like a bug introduced by the rewrite, since the "old version", 
did properly terminate that string.

It seems like that on x86 the memory after the string - coincidentally - is not zeroed
(atleast that's how I can explain it, maybe it's some other architecture difference?),
which leads to the schannel API throwing `SEC_E_SECPKG_NOT_FOUND`.
